### PR TITLE
Add the missing PATH_ASSETS on sokol platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,7 @@ ASSETS_JSON := $(shell find $(ASSETS_SRC_DIR) -type f -name '*.json')
 ASSETS_ENC_QOI := $(ASSETS_PNG:assets/%.png=$(ASSETS_BUILD_DIR)/%.qoi)
 ASSETS_ENC_QOA := $(ASSETS_WAV:assets/%.wav=$(ASSETS_BUILD_DIR)/%.qoa)
 ASSETS_CP_JSON := $(ASSETS_JSON:assets/%.json=$(ASSETS_BUILD_DIR)/%.json)
+ASSETS_PATH := $(shell pwd)
 
 assets: qoiconv qoaconv assets_build
 assets_build: $(ASSETS_ENC_QOI) $(ASSETS_ENC_QOA) $(ASSETS_CP_JSON)
@@ -204,7 +205,7 @@ sokol_build: $(SOKOL_COMMON_OBJ)
 
 $(OBJ_DIR)/sokol/%.o: %.c
 	mkdir -p $(dir $@)
-	$(CC) $(C_FLAGS) -DPLATFORM_SOKOL -MMD -MP -c $< -o $@
+	$(CC) $(C_FLAGS) -DPATH_ASSETS=$(ASSETS_PATH)/build/ -DPLATFORM_SOKOL -MMD -MP -c $< -o $@
 
 -include $(SOKOL_COMMON_DEPS)
 


### PR DESCRIPTION
I found that the following comands do not work on macOS and Ubuntu
```
make sokol
build/game_sokol
```
The reason is that makefile does not specify `PATH_ASSETS`. The more elegant way may be modification on `high_impact` directly. But I found `get_cwd` is not available on windows platform. 
```
char sokol_path_assets[PATH_MAX];

#ifdef PATH_ASSETS
        path_assets = TOSTRING(PATH_ASSETS);
#else
        if (getcwd(sokol_path_assets, sizeof(sokol_path_assets)) != NULL) {
                path_assets = sokol_path_assets;
        }
#endif
```